### PR TITLE
DOI identifier added to the metadata of the article

### DIFF
--- a/isaw-papers-xhtml-template.xhtml
+++ b/isaw-papers-xhtml-template.xhtml
@@ -31,7 +31,7 @@
  <meta name="DCTERMS.license" content="Creative Commons Attribution 4.0 Unported (CC-BY)" />
  <meta name="DCTERMS.bibliographicCitation" content="Sebastian Heath. (2016) " />
  <meta name="DCTERMS.isPartOf" content="ISAW Papers" />
- <meta name="dc:identifier" href="info:doi/2333.1/k98sf96r"/>
+ <meta name="DCTERMS.identifier.DOI" content="2333.1/k98sf96r"/>
 	 
  <link rel="dcterms:isPartOf" href="http://www.worldcat.org/oclc/756047783" />
  <link rel="dcterms:isPartOf" href="urn:issn:2164-1471" />
@@ -56,7 +56,7 @@
  
  <h2><span rel="dcterms:creator"><a rel="dcterms:identifier" href="http://viaf.org/viaf/220831018" property="foaf:name">Sebastian Heath</a></span></h2>
  
- <p class="doi"><a href="http://doi.org/2333.1/k98sf96r">http://doi.org/2333.1/k98sf96r</a></p>
+ <p class="doi"><a rel="dcterms:identifier" href="http://doi.org/2333.1/k98sf96r">http://doi.org/2333.1/k98sf96r</a></p>
  
  <p class="subjects"><em>Library of Congress Subjects:</em> <a rel="dcterms:subject" href="http://id.loc.gov/authorities/subjects/sh98003953">Scholarly Electronic Publishing</a>; <a rel="dcterms:subject" href="http://id.loc.gov/authorities/subjects/sh85105855">Pottery, Roman</a>.</p>
  

--- a/isaw-papers-xhtml-template.xhtml
+++ b/isaw-papers-xhtml-template.xhtml
@@ -32,7 +32,7 @@
  <meta name="DCTERMS.bibliographicCitation" content="Sebastian Heath. (2016) " />
  <meta name="DCTERMS.isPartOf" content="ISAW Papers" />
   
- <link rel="dcterms:identifier" href="info:doi/2333.1/k98sf96r"/>
+ <link rel="dc:identifier" href="info:doi/2333.1/k98sf96r"/>
  <link rel="dcterms:isPartOf" href="http://www.worldcat.org/oclc/756047783" />
  <link rel="dcterms:isPartOf" href="urn:issn:2164-1471" />
  <link rel="dcterms:isPartOf" href="http://isaw.nyu.edu/publications/isaw-papers" />

--- a/isaw-papers-xhtml-template.xhtml
+++ b/isaw-papers-xhtml-template.xhtml
@@ -31,7 +31,8 @@
  <meta name="DCTERMS.license" content="Creative Commons Attribution 4.0 Unported (CC-BY)" />
  <meta name="DCTERMS.bibliographicCitation" content="Sebastian Heath. (2016) " />
  <meta name="DCTERMS.isPartOf" content="ISAW Papers" />
-
+  
+ <link rel="dcterms:identifier" href="info:doi/2333.1/k98sf96r"/>
  <link rel="dcterms:isPartOf" href="http://www.worldcat.org/oclc/756047783" />
  <link rel="dcterms:isPartOf" href="urn:issn:2164-1471" />
  <link rel="dcterms:isPartOf" href="http://isaw.nyu.edu/publications/isaw-papers" />
@@ -55,7 +56,7 @@
  
  <h2><span rel="dcterms:creator"><a rel="dcterms:identifier" href="http://viaf.org/viaf/220831018" property="foaf:name">Sebastian Heath</a></span></h2>
  
- <p class="doi"><a property="dcterms:identifier" href="http://doi.org/2333.1/k98sf96r">http://doi.org/2333.1/k98sf96r</a></p>
+ <p class="doi"><a href="http://doi.org/2333.1/k98sf96r">http://doi.org/2333.1/k98sf96r</a></p>
  
  <p class="subjects"><em>Library of Congress Subjects:</em> <a rel="dcterms:subject" href="http://id.loc.gov/authorities/subjects/sh98003953">Scholarly Electronic Publishing</a>; <a rel="dcterms:subject" href="http://id.loc.gov/authorities/subjects/sh85105855">Pottery, Roman</a>.</p>
  

--- a/isaw-papers-xhtml-template.xhtml
+++ b/isaw-papers-xhtml-template.xhtml
@@ -31,8 +31,8 @@
  <meta name="DCTERMS.license" content="Creative Commons Attribution 4.0 Unported (CC-BY)" />
  <meta name="DCTERMS.bibliographicCitation" content="Sebastian Heath. (2016) " />
  <meta name="DCTERMS.isPartOf" content="ISAW Papers" />
-  
- <link rel="dc:identifier" href="info:doi/2333.1/k98sf96r"/>
+ <meta name="dc:identifier" href="info:doi/2333.1/k98sf96r"/>
+	 
  <link rel="dcterms:isPartOf" href="http://www.worldcat.org/oclc/756047783" />
  <link rel="dcterms:isPartOf" href="urn:issn:2164-1471" />
  <link rel="dcterms:isPartOf" href="http://isaw.nyu.edu/publications/isaw-papers" />


### PR DESCRIPTION
After visiting several websites with online publications, I looked at  two that were using doi : Open library of Humanities and Taylor and Francis. They both used dc.identifier anfd I haven't met any other solutions.

- Taylor and Francis adds an attribute `scheme="doi"` : `<meta name="dc.Identifier" scheme="doi" content="10.1080/24748668.2017.1405612" />` (https://www.tandfonline.com/doi/full/10.1080/24748668.2017.1405612)

- The library of humanists uses a refined element : `<meta name="DC.Identifier.DOI" content="10.16995/dm.54"/>` (https://journal.digitalmedievalist.org/articles/10.16995/dm.54/)

I then found the dc-citation guidelines, which have a paragraph on Electronic-only Articles and tried to follow those guidelines.

http://dublincore.org/documents/dc-citation-guidelines/

`<link rel="dc:identifier" href="info:doi/2333.1/k98sf96r"/>`

I was not sure if I had to put those elements in a link or in a meta element.

