### PR TITLE
changing #toc into #tableofcontents

### DIFF
--- a/isaw-papers-xhtml-template.xhtml
+++ b/isaw-papers-xhtml-template.xhtml
@@ -61,7 +61,7 @@
  <p class="subjects"><em>Library of Congress Subjects:</em> <a rel="dcterms:subject" href="http://id.loc.gov/authorities/subjects/sh98003953">Scholarly Electronic Publishing</a>; <a rel="dcterms:subject" href="http://id.loc.gov/authorities/subjects/sh85105855">Pottery, Roman</a>.</p>
  
  <!-- I do not like having a div here. -->
- <div id="toc">
+ <div id="tableofcontents">
  <p>Table of Contents</p>
  <ul>
   <li><a href="#section1">Example Paragraphs</a></li>


### PR DESCRIPTION
As all the files and isaw-publications.css use the id `tableofcontents` i thought that maybe changing the template might be the easiest solution. 